### PR TITLE
Using the R_HOME environmental variable

### DIFF
--- a/plugin/src/main/groovy/com/umayrh/gradle/RScriptTask.groovy
+++ b/plugin/src/main/groovy/com/umayrh/gradle/RScriptTask.groovy
@@ -17,6 +17,7 @@ class RScriptTask extends DefaultTask {
 
     @Input
     String expression = null
+    
 
     @TaskAction
     def exec() {
@@ -24,8 +25,14 @@ class RScriptTask extends DefaultTask {
             if (expression == null) {
                  throw new GradleException("Must specify an Rscript expression")
             }
+            def env = System.getenv()['R_HOME']
+            if (env == null) {
+                // commandLine is part of Exec task
+                commandLine 'Rscript', '-e', expression
+            }else{
             // commandLine is part of Exec task
-            commandLine 'Rscript', '-e', expression
+                commandLine env +'/bin/Rscript', '-e', expression
+            }
         }
     }
 }


### PR DESCRIPTION
Using the R_HOME environmental variable if it is available. would be helpful in systems installed with multiple versions. I didnt see another place to set it, unless I missed something. So I am proposing this change. THIS CHANGE IS NOT TESTED.